### PR TITLE
fix: logout button not working in profile dropdown

### DIFF
--- a/resources/default/js/Components/Navigation/ProfileDropdown.vue
+++ b/resources/default/js/Components/Navigation/ProfileDropdown.vue
@@ -95,14 +95,13 @@
         <div class="border-t border-border my-2" />
 
         <!-- Authentication -->
-        <form @submit.prevent="emit('logout')">
-          <jet-dropdown-link
-            as="button"
-            btn-class="font-semibold"
-          >
-            {{ __("Logout") }}
-          </jet-dropdown-link>
-        </form>
+        <jet-dropdown-link
+          as="button"
+          btn-class="font-semibold"
+          @click="emit('logout')"
+        >
+          {{ __("Logout") }}
+        </jet-dropdown-link>
       </ul>
     </NavigationMenuLink>
   </NavigationMenuContent>


### PR DESCRIPTION
## Problem

The logout button in the desktop profile dropdown did nothing when clicked.

## Root cause

In `ProfileDropdown.vue`, logout relied on a native form submit:

```html
<form @submit.prevent="emit('logout')">
  <jet-dropdown-link as="button" .../>  <!-- renders <button type="submit"> -->
</form>
```

This form lives inside reka-ui's `NavigationMenuLink`. When the submit button is clicked, `NavigationMenuLink`'s click handler synchronously dispatches its `rootContentDismiss` event, which closes the dropdown. Vue flushes that DOM update in the microtask checkpoint that runs immediately after the click listener returns — **unmounting the form before the browser performs the submit button's default action**. So the form's `submit` event never fires, `emit('logout')` is never called, and the user is never logged out.

The mobile/responsive logout uses a plain form inside a `Sheet` (not a `NavigationMenuLink`), which is why it kept working — consistent with the reported symptom.

## Fix

Trigger logout from a synchronous `@click` on the dropdown link instead of depending on the form-submit default action. The `@click` runs during click dispatch — before the menu unmounts — so `emit('logout')` reaches `MainNavbarCustom`'s `router.post(route('logout'))` reliably.

```html
<jet-dropdown-link as="button" btn-class="font-semibold" @click="emit('logout')">
  {{ __("Logout") }}
</jet-dropdown-link>
```

The event chain (`ProfileDropdown` → `NavDynamicItem` → `MainNavbarCustom`) is unchanged.

## Testing notes

This is a client-side event-timing bug. The repo has no JS test harness (no Vitest/Jest) and the existing Pest feature tests can't reproduce a browser microtask-ordering issue, so no automated test was added. Verified by tracing the event flow against the bundled reka-ui `NavigationMenuLink` click handler.



---