### PR TITLE
feat: Request-tracked command queue APIs

### DIFF
--- a/app/Http/Controllers/Api/ApiCommandQueueController.php
+++ b/app/Http/Controllers/Api/ApiCommandQueueController.php
@@ -2,9 +2,13 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Enums\CommandQueueStatus;
 use App\Jobs\RunCommandQueuesFromRequestJob;
+use App\Models\CommandQueue;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class ApiCommandQueueController extends ApiController
@@ -31,8 +35,63 @@ class ApiCommandQueueController extends ApiController
             ],
         ]);
 
-        RunCommandQueuesFromRequestJob::dispatch($request->collect(), null);
+        $requestId = Str::uuid()->toString();
+        $payload = $request->collect()->put('request_id', $requestId);
 
-        return $this->success(null, 'Command queued successfully.');
+        Cache::put($this->requestCacheKey($requestId), true, now()->addDay());
+        RunCommandQueuesFromRequestJob::dispatch($payload, null);
+
+        return $this->success([
+            'request_id' => $requestId,
+        ], 'Command queued successfully.');
+    }
+
+    /**
+     * Get the status of all command queues created by an API request.
+     */
+    public function show(string $requestId): JsonResponse
+    {
+        if (! Str::isUuid($requestId)) {
+            return $this->error('Command queue request not found.', 'request_not_found', 404);
+        }
+
+        $commandQueues = CommandQueue::query()
+            ->where('request_id', $requestId)
+            ->get(['id', 'server_id', 'player_id', 'status', 'output']);
+
+        if ($commandQueues->isEmpty()) {
+            if (Cache::has($this->requestCacheKey($requestId))) {
+                return $this->success([
+                    'request_id' => $requestId,
+                    'status' => CommandQueueStatus::PENDING->value,
+                    'summary' => [],
+                    'commands' => [],
+                ], 'Ok');
+            }
+
+            return $this->error('Command queue request not found.', 'request_not_found', 404);
+        }
+
+        $statusCounts = $commandQueues
+            ->countBy(fn (CommandQueue $commandQueue) => $commandQueue->status->value);
+
+        $status = match (true) {
+            $commandQueues->contains('status', CommandQueueStatus::RUNNING) => CommandQueueStatus::RUNNING->value,
+            $commandQueues->contains(fn (CommandQueue $commandQueue) => in_array($commandQueue->status, [CommandQueueStatus::PENDING, CommandQueueStatus::DEFERRED], true)) => CommandQueueStatus::PENDING->value,
+            $commandQueues->contains(fn (CommandQueue $commandQueue) => in_array($commandQueue->status, [CommandQueueStatus::FAILED, CommandQueueStatus::CANCELLED], true)) => CommandQueueStatus::FAILED->value,
+            default => CommandQueueStatus::COMPLETED->value,
+        };
+
+        return $this->success([
+            'request_id' => $requestId,
+            'status' => $status,
+            'summary' => $statusCounts,
+            'commands' => $commandQueues,
+        ], 'Ok');
+    }
+
+    private function requestCacheKey(string $requestId): string
+    {
+        return "command-queue-request:{$requestId}";
     }
 }

--- a/app/Http/Controllers/Api/ApiRankController.php
+++ b/app/Http/Controllers/Api/ApiRankController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Models\Player;
 use App\Models\Rank;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Http\JsonResponse;
 
 class ApiRankController extends ApiController
@@ -23,16 +26,23 @@ class ApiRankController extends ApiController
         }
 
         $members = User::whereNotNull('discord_user_id')
-            ->whereHas('players', function ($query) use ($rank) {
+            ->whereHas('players', function (Builder $query) use ($rank) {
                 $query->where('rank_id', $rank->id);
             })
+            ->with(['players' => function (BelongsToMany $query) use ($rank) {
+                $query->where('rank_id', $rank->id)
+                    ->orderBy('players.id')
+                    ->select(['players.id', 'players.username']);
+            }])
             ->get(['id', 'username', 'discord_user_id'])
-            ->map(function (User $user) {
-                return [
+            ->flatMap(function (User $user) {
+                return $user->players->map(fn (Player $player) => [
+                    'player_id' => $player->id,
+                    'player_username' => $player->username,
                     'user_id' => $user->id,
                     'username' => $user->username,
                     'discord_id' => $user->discord_user_id,
-                ];
+                ]);
             });
 
         return $this->success($members, 'Ok');

--- a/app/Http/Controllers/Api/ApiUserController.php
+++ b/app/Http/Controllers/Api/ApiUserController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Player;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+
+class ApiUserController extends ApiController
+{
+    /**
+     * Find a MineTrax user and their linked Minecraft usernames by Discord ID.
+     */
+    public function showByDiscordId(string $discordId): JsonResponse
+    {
+        $user = User::query()
+            ->where('discord_user_id', $discordId)
+            ->with('players:id,username')
+            ->first();
+
+        if (! $user) {
+            return $this->error('User not found.', 'user_not_found', 404);
+        }
+
+        return $this->success([
+            [
+                'user_id' => $user->id,
+                'linked_users' => $user->players->map(fn (Player $player) => [
+                    'player_id' => $player->id,
+                    'username' => $player->username,
+                ])->values(),
+            ],
+        ], 'Ok');
+    }
+}

--- a/app/Jobs/RunCommandQueuesFromRequestJob.php
+++ b/app/Jobs/RunCommandQueuesFromRequestJob.php
@@ -102,6 +102,7 @@ class RunCommandQueuesFromRequestJob implements ShouldQueue
         }
         $parsedCommandString = Helper::replacePlaceholders($rawCommand, $params);
         $commandQueue = CommandQueue::create([
+            'request_id' => $this->request->get('request_id'),
             'server_id' => $serverId,
             'command_id' => null,
             'parsed_command' => $parsedCommandString,

--- a/database/migrations/2026_08_10_104907_add_request_id_to_command_queues_table.php
+++ b/database/migrations/2026_08_10_104907_add_request_id_to_command_queues_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('command_queues', function (Blueprint $table) {
+            $table->uuid('request_id')->nullable()->index()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('command_queues', function (Blueprint $table) {
+            $table->dropColumn('request_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\ApiPlayerController;
 use App\Http\Controllers\Api\ApiRankController;
 use App\Http\Controllers\Api\ApiServerChatlogController;
 use App\Http\Controllers\Api\ApiServerConsolelogController;
+use App\Http\Controllers\Api\ApiUserController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -38,8 +39,12 @@ Route::middleware(['auth.api-key'])->group(function () {
     // Discord Rank Sync: list users which have a player of given rank linked, with their discord id.
     Route::get('v1/ranks/{rank}/members', [ApiRankController::class, 'getRankMembers'])->name('api.ranks.members');
 
+    // Discord integration: find a MineTrax user and their linked Minecraft users.
+    Route::get('v1/users/{discordId}', [ApiUserController::class, 'showByDiscordId'])->name('api.users.discord.show');
+
     // Command Queue: queue a command for execution.
     Route::post('v1/command-queue', [ApiCommandQueueController::class, 'store'])->name('api.command-queue.store');
+    Route::get('v1/command-queue/{requestId}', [ApiCommandQueueController::class, 'show'])->name('api.command-queue.show');
 
     // Intel APIs: used by Server to Report Player/Server Intelligence Data.
     Route::post('v1/intel/player/session-init', [ApiMinecraftPlayerIntelController::class, 'postSessionInit'])->name('api.intel.player.session-init');

--- a/tests/Feature/ApiCommandQueueTest.php
+++ b/tests/Feature/ApiCommandQueueTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Enums\CommandQueueStatus;
 use App\Jobs\RunCommandQueuesFromRequestJob;
+use App\Models\CommandQueue;
 use App\Models\Server;
 use App\Settings\PluginSettings;
 use App\Utils\Helpers\CryptoUtils;
@@ -22,6 +24,16 @@ class ApiCommandQueueTest extends TestCase
         return $this->postJson($uri, $data, [
             'X-API-KEY' => $pluginSettings->plugin_api_key,
             'X-SIGNATURE' => CryptoUtils::generateHmacSignature(json_encode($data), $pluginSettings->plugin_api_secret),
+        ]);
+    }
+
+    private function getJsonWithApiCredentials(string $uri): TestResponse
+    {
+        $pluginSettings = app(PluginSettings::class);
+
+        return $this->getJson($uri, [
+            'X-API-KEY' => $pluginSettings->plugin_api_key,
+            'X-SIGNATURE' => CryptoUtils::generateHmacSignature(url($uri), $pluginSettings->plugin_api_secret),
         ]);
     }
 
@@ -51,7 +63,8 @@ class ApiCommandQueueTest extends TestCase
         ]);
 
         $response->assertStatus(200)
-            ->assertJson(['status' => 'success']);
+            ->assertJson(['status' => 'success'])
+            ->assertJsonStructure(['data' => ['request_id']]);
 
         Queue::assertPushed(RunCommandQueuesFromRequestJob::class);
     }
@@ -78,7 +91,8 @@ class ApiCommandQueueTest extends TestCase
             ->assertJson([
                 'status' => 'success',
                 'message' => 'Command queued successfully.',
-            ]);
+            ])
+            ->assertJsonStructure(['data' => ['request_id']]);
 
         Queue::assertPushed(RunCommandQueuesFromRequestJob::class);
     }
@@ -100,7 +114,8 @@ class ApiCommandQueueTest extends TestCase
             ->assertJson([
                 'status' => 'success',
                 'message' => 'Command queued successfully.',
-            ]);
+            ])
+            ->assertJsonStructure(['data' => ['request_id']]);
 
         Queue::assertPushed(RunCommandQueuesFromRequestJob::class);
     }
@@ -162,5 +177,74 @@ class ApiCommandQueueTest extends TestCase
             ->assertJsonValidationErrors(['servers.0.id']);
 
         Queue::assertNotPushed(RunCommandQueuesFromRequestJob::class);
+    }
+
+    public function test_it_returns_command_queue_status_by_request_id()
+    {
+        $requestId = fake()->uuid();
+        $pendingCommand = CommandQueue::factory()->create([
+            'request_id' => $requestId,
+            'status' => CommandQueueStatus::PENDING,
+        ]);
+        $completedCommand = CommandQueue::factory()->completed()->create([
+            'request_id' => $requestId,
+        ]);
+
+        $this->getJsonWithApiCredentials("/api/v1/command-queue/{$requestId}")
+            ->assertOk()
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    'request_id' => $requestId,
+                    'status' => CommandQueueStatus::PENDING->value,
+                    'summary' => [
+                        CommandQueueStatus::PENDING->value => 1,
+                        CommandQueueStatus::COMPLETED->value => 1,
+                    ],
+                    'commands' => [
+                        ['id' => $pendingCommand->id],
+                        ['id' => $completedCommand->id],
+                    ],
+                ],
+            ]);
+    }
+
+    public function test_it_returns_pending_before_the_request_job_creates_command_queues()
+    {
+        Queue::fake();
+
+        $server = Server::factory()->create(['webquery_port' => 25575]);
+
+        $response = $this->postJsonWithApiCredentials('/api/v1/command-queue', [
+            'scope' => 'global',
+            'command' => 'say Hello World',
+            'servers' => [['id' => $server->id]],
+        ])->assertOk();
+
+        $requestId = $response->json('data.request_id');
+
+        $this->getJsonWithApiCredentials("/api/v1/command-queue/{$requestId}")
+            ->assertOk()
+            ->assertJson([
+                'status' => 'success',
+                'data' => [
+                    'request_id' => $requestId,
+                    'status' => CommandQueueStatus::PENDING->value,
+                    'summary' => [],
+                    'commands' => [],
+                ],
+            ]);
+    }
+
+    public function test_it_returns_not_found_for_an_unknown_request_id()
+    {
+        $requestId = fake()->uuid();
+
+        $this->getJsonWithApiCredentials("/api/v1/command-queue/{$requestId}")
+            ->assertNotFound()
+            ->assertJson([
+                'status' => 'error',
+                'type' => 'request_not_found',
+            ]);
     }
 }

--- a/tests/Feature/ApiRankMembersTest.php
+++ b/tests/Feature/ApiRankMembersTest.php
@@ -82,7 +82,8 @@ class ApiRankMembersTest extends TestCase
         $userWithoutDiscord = User::factory()->create(['discord_user_id' => null]);
         $userOfOtherRank = User::factory()->create(['discord_user_id' => '876543210987654321']);
 
-        $userWithDiscord->players()->attach(Player::factory()->create(['uuid' => fake()->uuid(), 'rank_id' => $rank->id]));
+        $rankedPlayer = Player::factory()->create(['uuid' => fake()->uuid(), 'username' => 'RankedPlayer', 'rank_id' => $rank->id]);
+        $userWithDiscord->players()->attach($rankedPlayer);
         $userWithoutDiscord->players()->attach(Player::factory()->create(['uuid' => fake()->uuid(), 'rank_id' => $rank->id]));
         $userOfOtherRank->players()->attach(Player::factory()->create(['uuid' => fake()->uuid(), 'rank_id' => $otherRank->id]));
 
@@ -94,6 +95,8 @@ class ApiRankMembersTest extends TestCase
                 'status' => 'success',
                 'data' => [
                     [
+                        'player_id' => $rankedPlayer->id,
+                        'player_username' => 'RankedPlayer',
                         'user_id' => $userWithDiscord->id,
                         'username' => $userWithDiscord->username,
                         'discord_id' => '123456789012345678',
@@ -122,17 +125,20 @@ class ApiRankMembersTest extends TestCase
             ->assertJsonPath('data.0.user_id', $user->id);
     }
 
-    public function test_user_with_multiple_players_of_same_rank_is_returned_only_once()
+    public function test_each_player_of_the_same_rank_is_returned_with_its_player_id()
     {
         $rank = Rank::factory()->create(['shortname' => 'crazy']);
 
         $user = User::factory()->create(['discord_user_id' => '123456789012345678']);
-        $user->players()->attach(Player::factory()->create(['uuid' => fake()->uuid(), 'rank_id' => $rank->id]));
-        $user->players()->attach(Player::factory()->create(['uuid' => fake()->uuid(), 'rank_id' => $rank->id]));
+        $firstPlayer = Player::factory()->create(['uuid' => fake()->uuid(), 'username' => 'FirstPlayer', 'rank_id' => $rank->id]);
+        $secondPlayer = Player::factory()->create(['uuid' => fake()->uuid(), 'username' => 'SecondPlayer', 'rank_id' => $rank->id]);
+        $user->players()->attach([$firstPlayer->id, $secondPlayer->id]);
 
         $this->getJsonWithApiCredentials('/api/v1/ranks/crazy/members')
             ->assertStatus(200)
-            ->assertJsonCount(1, 'data');
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.player_id', $firstPlayer->id)
+            ->assertJsonPath('data.1.player_id', $secondPlayer->id);
     }
 
     public function test_it_returns_empty_list_when_rank_has_no_members()

--- a/tests/Feature/ApiUserByDiscordIdTest.php
+++ b/tests/Feature/ApiUserByDiscordIdTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\Player;
+use App\Models\User;
+use App\Settings\PluginSettings;
+use App\Utils\Helpers\CryptoUtils;
+use Illuminate\Testing\TestResponse;
+
+function getUserByDiscordId(string $discordId): TestResponse
+{
+    $uri = "/api/v1/users/{$discordId}";
+    $pluginSettings = app(PluginSettings::class);
+
+    return test()->getJson($uri, [
+        'X-API-KEY' => $pluginSettings->plugin_api_key,
+        'X-SIGNATURE' => CryptoUtils::generateHmacSignature(url($uri), $pluginSettings->plugin_api_secret),
+    ]);
+}
+
+it('rejects requests without API credentials', function () {
+    $this->getJson('/api/v1/users/123456789012345678')->assertUnauthorized();
+});
+
+it('returns a user and their linked Minecraft usernames by Discord ID', function () {
+    $user = User::factory()->create(['discord_user_id' => '123456789012345678']);
+    $xteri = Player::factory()->create(['uuid' => fake()->uuid(), 'username' => 'xteri']);
+    $steve = Player::factory()->create(['uuid' => fake()->uuid(), 'username' => 'steve']);
+    $user->players()->attach([$xteri->id, $steve->id]);
+
+    getUserByDiscordId('123456789012345678')
+        ->assertOk()
+        ->assertJson([
+            'status' => 'success',
+            'message' => 'Ok',
+            'data' => [
+                [
+                    'user_id' => $user->id,
+                    'linked_users' => [
+                        [
+                            'player_id' => $xteri->id,
+                            'username' => 'xteri',
+                        ],
+                        [
+                            'player_id' => $steve->id,
+                            'username' => 'steve',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+});
+
+it('returns an empty linked users array when the user has no linked players', function () {
+    $user = User::factory()->create(['discord_user_id' => '123456789012345678']);
+
+    getUserByDiscordId('123456789012345678')
+        ->assertOk()
+        ->assertJsonPath('data.0.user_id', $user->id)
+        ->assertJsonCount(0, 'data.0.linked_users');
+});
+
+it('returns not found for an unknown Discord ID', function () {
+    getUserByDiscordId('123456789012345678')
+        ->assertNotFound()
+        ->assertJson([
+            'status' => 'error',
+            'type' => 'user_not_found',
+        ]);
+});

--- a/tests/Feature/QueuedJobDispatchTest.php
+++ b/tests/Feature/QueuedJobDispatchTest.php
@@ -22,6 +22,7 @@ class QueuedJobDispatchTest extends TestCase
         $server = Server::factory()->create(['webquery_port' => 25575]);
 
         $request = collect([
+            'request_id' => fake()->uuid(),
             'scope' => 'global',
             'command' => 'say Hello World',
             'execute_at' => null,
@@ -32,6 +33,7 @@ class QueuedJobDispatchTest extends TestCase
         $job->handle();
 
         $this->assertDatabaseHas('command_queues', [
+            'request_id' => $request->get('request_id'),
             'server_id' => $server->id,
             'parsed_command' => 'say Hello World',
             'status' => CommandQueueStatus::PENDING->value,


### PR DESCRIPTION
Introduce UUID-based request tracking for command queue submissions by returning a `request_id`, persisting it on `command_queues`, and adding a status endpoint to fetch aggregate/request-level progress and queued command details. Also add a new Discord lookup endpoint to fetch a MineTrax user with linked Minecraft players, and update rank member responses to include player-level entries (`player_id`, `player_username`). Feature tests were expanded to cover the new endpoints and response shapes.